### PR TITLE
generate-ta: default to local TA generator dir

### DIFF
--- a/.github/workflows/check-ta.yaml
+++ b/.github/workflows/check-ta.yaml
@@ -20,6 +20,8 @@ jobs:
       - name: Check Trusted Artifact variants
         id: check
         run: hack/generate-ta-tasks.sh
+        env:
+          TRUSTED_ARTIFACTS: github.com/konflux-ci/build-definitions/task-generator/trusted-artifacts@latest
 
       # TODO: re-enable this check
       # - name: Check missing Trusted Artifact variants

--- a/hack/generate-ta-tasks.sh
+++ b/hack/generate-ta-tasks.sh
@@ -19,7 +19,7 @@ command -v go &> /dev/null || { echo Please install golang to run this tool; exi
 HACK_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 TASK_DIR="$(realpath "${ROOT_DIR}/task")"
-: "${TRUSTED_ARTIFACTS=github.com/konflux-ci/build-definitions/task-generator/trusted-artifacts@latest}"
+: "${TRUSTED_ARTIFACTS=../build-definitions/task-generator/trusted-artifacts}"
 
 tashdir="$(mktemp --dry-run)"
 if [[ -d "${TRUSTED_ARTIFACTS}" ]]; then


### PR DESCRIPTION
For more convenient local development, use a trusted-artifacts generator from a local directory by default when running the generate-ta-tasks.sh script.

In the CI workflow, use the actual upstream TA generator.

Note: this is a mostly bogus commit, just to test how cruft will handle custom patches.